### PR TITLE
Basic auth0 integration

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import { Constants } from 'expo';
 
 import { CoralHeader, colors } from './src/ui.js';
 
+import { LoginScreen } from './src/screens/LoginScreen.js';
 import { MyRecordsScreen } from './src/screens/MyRecordsScreen.js';
 import { ViewRecordScreen } from './src/screens/ViewRecordScreen.js';
 import { RequestHealthTipScreen } from './src/screens/RequestHealthTipScreen.js';
@@ -38,14 +39,14 @@ const MyRecordsNavigator = StackNavigator({
   AddRecordManual: { screen: AddRecordManualScreen },
   AddBloodTestRecord: {screen: AddBloodTestRecordScreen},
   AddGeneticTestRecord: {screen: AddGeneticTestRecordScreen},
-  ViewImage: { 
+  ViewImage: {
     screen: ViewImageScreen,
     navigationOptions: ({ navigation }) => ({
       title: 'Photo Record View',
       tabBarVisible: false
     })
   },
-  QRCodeReader: { 
+  QRCodeReader: {
     screen: QRCodeReaderScreen,
     navigationOptions: ({ navigation }) => ({
       title: 'QR Code',
@@ -67,7 +68,7 @@ const SettingsNavigator = StackNavigator({
   Settings: { screen: SettingsScreen },
   AccountInfo: { screen: AccountInfoScreen },
   Profile: { screen: ProfileScreen },
-  QRCodeReader: { 
+  QRCodeReader: {
     screen: QRCodeReaderScreen,
     navigationOptions: ({ navigation }) => ({
       title: 'QR Code',
@@ -88,7 +89,7 @@ function resetStack(navigation, routes) {
   }
 }
 
-const App = TabNavigator({
+const MainTabs = TabNavigator({
   MyRecords: {
     screen: MyRecordsNavigator,
     navigationOptions: ({ navigation }) => ( {
@@ -139,7 +140,7 @@ const App = TabNavigator({
         jumpToIndex(scene.index);
       }
     }),
-  }, 
+  },
 },
 {
   tabBarOptions:{
@@ -147,6 +148,13 @@ const App = TabNavigator({
   }
 }
 );
+
+const App = StackNavigator({
+  Login: { screen: LoginScreen },
+  MainTabs: { screen: MainTabs }
+},{
+  headerMode: 'none'
+});
 
 export default App;
 

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,0 +1,122 @@
+import React, { Component } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Button, Text } from 'react-native-elements';
+import { AuthSession } from 'expo';
+
+const auth0ClientId = 'u79wUql80IzN7AuLDqv3NIeC8XmtMEuq';
+const auth0Domain = 'https://mycoralhealth.auth0.com';
+const coraldServer = 'https://api.mycoralhealth.com/v0';
+
+function toQueryString(params) {
+  return '?' + Object.entries(params)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+}
+
+export class LoginScreen extends Component {
+  state = {
+    name: undefined,
+  };
+
+  _logout = async() => {
+    this.setState({ "name": undefined });
+  }
+
+  _loginWithAuth0 = async () => {
+    const redirectUrl = AuthSession.getRedirectUrl();
+    console.log(`Redirect URL (add this to Auth0): ${redirectUrl}`);
+    const result = await AuthSession.startAsync({
+      authUrl: `${auth0Domain}/authorize` + toQueryString({
+        client_id: auth0ClientId,
+        response_type: 'token',
+        scope: 'openid profile',
+        redirect_uri: redirectUrl,
+      }),
+    });
+
+    console.log(result);
+    if (result.type === 'success') {
+      this.handleParams(result.params);
+    }
+  }
+
+  handleParams = (responseObj) => {
+    if (responseObj.error) {
+      Alert.alert('Error', responseObj.error_description
+        || 'something went wrong while logging in');
+      return;
+    }
+
+    /*
+    // Get user metadata directly from Auth0
+    fetch(`${auth0Domain}/userinfo?access_token=${responseObj.access_token}`)
+      .then(response => {
+        if (response.status === 200) {
+          response.json().then(parsedResponse => {
+            console.log(parsedResponse);
+            const { name, email, picture } = parsedResponse
+
+            this.setState({ name });
+          })
+        }
+        else {
+          console.log('Something went wrong. ErrorCode: ', response.status);
+        }
+      })
+     */
+
+    // Get user metadata via our server
+    fetch(`${coraldServer}/session`, {"headers": {"X-MyCoral-AccessToken": responseObj.access_token}})
+      .then(response => {
+        if (response.status === 200) {
+          response.json().then(parsedResponse => {
+            console.log(parsedResponse);
+            const { name, picture } = parsedResponse
+
+            this.setState({ name });
+          })
+        }
+        else {
+          console.log('Something went wrong. ErrorCode: ', response.status);
+        }
+      })
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        {this.state.name !== undefined ?
+          <View>
+            <Text style={styles.title}>Hi {this.state.name}!</Text>
+            <Button
+              title='Continue'
+              onPress={() => this.props.navigation.navigate('MainTabs')}
+              style={styles.continue}
+            />
+            <Button title="Logout" onPress={this._logout} />
+          </View> :
+          <View>
+            <Button title="Login with Auth0" onPress={this._loginWithAuth0} />
+          </View>
+        }
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 20,
+    textAlign: 'center',
+    marginTop: 40,
+  },
+  continue: {
+    marginBottom: 20
+  }
+});


### PR DESCRIPTION
This PR adds a LoginScreen to the very top of the navigation hierarchy.

This login screen is functional now, but requires a number of refinements prior to merging:

  1. Automatically launch the login prompt, rather than having a "Login with Auth0" button
  2. Get proper branding on the Auth0 Web Auth screen (not sure why this isn't working — it appears to be configured correctly in Auth0)
  3. Put a "Logout" button that is accessible from inside the other app screens
  4. Carry the logged-in state around the entire app. 
     * The `responseObj.access_token` is required for making subsequent requests to `corald`
     * We may also want to keep some user info for display purposes

Important: We are using an Expo service for AuthSession, which requires using `exp start` instead of `react-native-scripts start`. See [here](https://github.com/react-community/create-react-native-app/issues/540#issuecomment-360730563).