### PR TITLE
Allows using corald server as an authenticated IPFS proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "jest-expo": "23.0.0",
-    "react-native-scripts": "1.8.1",
+    "react-native-scripts": "1.11.1",
     "react-test-renderer": "16.0.0"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",

--- a/src/const.js
+++ b/src/const.js
@@ -1,0 +1,3 @@
+
+export const CORALD_API = 'https://api.mycoralhealth.com/v0';
+//export const CORALD_API = 'http://192.168.1.72:8080/v0';

--- a/src/screens/AccountInfoScreen.js
+++ b/src/screens/AccountInfoScreen.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import React, { Component } from 'react';
 import { View, ScrollView } from 'react-native';
-import { Button, Text, FormLabel, FormInput } from 'react-native-elements';
+import { Button, Text, FormLabel, FormInput, CheckBox } from 'react-native-elements';
 import { NavigationActions } from 'react-navigation'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import nextFrame from 'next-frame';
@@ -136,7 +136,7 @@ export class AccountInfoScreen extends Component {
 
         <KeyboardAwareScrollView style={{ flex: 1 }}>
           <View style={{ flex: 1 }}>
-            <KeyInfo 
+            <KeyInfo
               keysPresent={this.state.keysPresent}
               generateKeys={this.generateKeys.bind(this)}
               revokeKeys={this.revokeKeys.bind(this)}
@@ -147,7 +147,7 @@ export class AccountInfoScreen extends Component {
             Blockchain info
           </Text>
           <FormLabel>Blockchain ETH address</FormLabel>
-          <FormInput 
+          <FormInput
             value={this.state.ethAddress}
             placeholder='0x8A09990601E7FF5Cdcc...'
             returnKeyType='done'
@@ -167,57 +167,67 @@ export class AccountInfoScreen extends Component {
           <Text h4 style={{textAlign: 'left', marginTop: 20, marginLeft: 20}}>
             IPFS settings
           </Text>
-          <FormLabel>IPFS protocol</FormLabel>
-          <FormInput 
-            value={this.state.ipfsInfo.protocol}
-            placeholder='http'
-            returnKeyType='done'
-            autoCapitalize='none'
-            inputStyle={{color:'black'}}
-            autoCorrect={false}
-            onChangeText={(text) => this.updateIpfsInfo('protocol', text)}/>
+          <CheckBox
+            center
+            containerStyle={{backgroundColor: colors.bg}}
+            title='Use custom server'
+            checked={this.state.ipfsInfo.useCustom}
+            onPress={() => this.updateIpfsInfo('useCustom', !this.state.ipfsInfo.useCustom)}
+          />
+          <View pointerEvents={this.state.ipfsInfo.useCustom ? 'auto' : 'none'}
+              style={{opacity: this.state.ipfsInfo.useCustom ? 1.0 : 0.2}}>
+            <FormLabel>IPFS protocol</FormLabel>
+            <FormInput
+              value={this.state.ipfsInfo.protocol}
+              placeholder='http'
+              returnKeyType='done'
+              autoCapitalize='none'
+              inputStyle={{color:'black'}}
+              autoCorrect={false}
+              onChangeText={(text) => this.updateIpfsInfo('protocol', text)}/>
 
-          <FormLabel>IPFS address</FormLabel>
-          <FormInput 
-            value={this.state.ipfsInfo.address}
-            placeholder='localhost'
-            autoCapitalize='none'
-            returnKeyType='done'
-            inputStyle={{color:'black'}}
-            autoCorrect={false}
-            onChangeText={(text) => this.updateIpfsInfo('address', text)}/>
+            <FormLabel>IPFS address</FormLabel>
+            <FormInput
+              value={this.state.ipfsInfo.address}
+              placeholder='localhost'
+              autoCapitalize='none'
+              returnKeyType='done'
+              inputStyle={{color:'black'}}
+              autoCorrect={false}
+              onChangeText={(text) => this.updateIpfsInfo('address', text)}/>
 
-          <FormLabel>IPFS port</FormLabel>
-          <FormInput 
-            value={this.state.ipfsInfo.port}
-            placeholder='50001'
-            autoCapitalize='none'
-            returnKeyType='done'
-            keyboardType='numeric'
-            inputStyle={{color:'black'}}
-            autoCorrect={false}
-            onChangeText={(text) => this.updateIpfsInfo('port', text)}/>
+            <FormLabel>IPFS port</FormLabel>
+            <FormInput
+              value={this.state.ipfsInfo.port}
+              placeholder='50001'
+              autoCapitalize='none'
+              returnKeyType='done'
+              keyboardType='numeric'
+              inputStyle={{color:'black'}}
+              autoCorrect={false}
+              onChangeText={(text) => this.updateIpfsInfo('port', text)}/>
 
-          <FormLabel>IPFS user name</FormLabel>
-          <FormInput 
-            value={this.state.ipfsInfo.userName}
-            placeholder='(optional)'
-            autoCapitalize='none'
-            returnKeyType='done'
-            inputStyle={{color:'black'}}
-            autoCorrect={false}
-            onChangeText={(text) => this.updateIpfsInfo('userName', text)}/>
+            <FormLabel>IPFS user name</FormLabel>
+            <FormInput
+              value={this.state.ipfsInfo.userName}
+              placeholder='(optional)'
+              autoCapitalize='none'
+              returnKeyType='done'
+              inputStyle={{color:'black'}}
+              autoCorrect={false}
+              onChangeText={(text) => this.updateIpfsInfo('userName', text)}/>
 
-          <FormLabel>IPFS password</FormLabel>
-          <FormInput 
-            value={this.state.ipfsInfo.password}
-            placeholder='(optional)'
-            autoCapitalize='none'
-            returnKeyType='done'
-            secureTextEntry={true}
-            inputStyle={{color:'black'}}
-            autoCorrect={false}
-            onChangeText={(text) => this.updateIpfsInfo('password', text)}/>
+            <FormLabel>IPFS password</FormLabel>
+            <FormInput
+              value={this.state.ipfsInfo.password}
+              placeholder='(optional)'
+              autoCapitalize='none'
+              returnKeyType='done'
+              secureTextEntry={true}
+              inputStyle={{color:'black'}}
+              autoCorrect={false}
+              onChangeText={(text) => this.updateIpfsInfo('password', text)}/>
+          </View>
 
           <View style={{ height: 300 }}/>
 

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -5,10 +5,10 @@ import { AuthSession } from 'expo';
 
 import store from '../utilities/store';
 import { colors, MessageIndicator } from '../ui';
+import { CORALD_API } from '../const';
 
 const auth0ClientId = 'u79wUql80IzN7AuLDqv3NIeC8XmtMEuq';
 const auth0Domain = 'https://mycoralhealth.auth0.com';
-const coraldServer = 'https://api.mycoralhealth.com/v0';
 
 function toQueryString(params) {
   return '?' + Object.entries(params)
@@ -83,12 +83,12 @@ export class LoginScreen extends Component {
   // Get user metadata via corald
   getUserInfo = (responseObj) => {
 
-    fetch(`${coraldServer}/session`, {"headers": {"X-MyCoral-AccessToken": responseObj.access_token}})
+    fetch(`${CORALD_API}/session`, {"headers": {"X-MyCoral-AccessToken": responseObj.access_token}})
       .then(response => {
         if (response.status === 200) {
           response.json().then(async (userInfo) => {
             console.log(userInfo);
-            
+
             userInfo.accessToken = responseObj.access_token;
 
             await store.setUserInfo(userInfo);

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -52,12 +52,14 @@ const getPerUserStoreKey = async () => {
 }
 
 const getIPFSProvider = async () => {
-  let info = await AsyncStorage.getItem(`${await getPerUserStoreKey()}.${IPFS_INFO}`); 
-  if (!info) {
-    return { protocol:'http', address:'localhost', port:'5001', userName: null, password: null };
+  const info = { useCustom:false, protocol:null, address:null, port:null, userName: null, password: null };
+
+  let loadedInfo = await AsyncStorage.getItem(`${await getPerUserStoreKey()}.${IPFS_INFO}`);
+  if (loadedInfo) {
+    Object.assign(info, JSON.parse(loadedInfo) || {});
   }
 
-  return JSON.parse(info);
+  return info;
 }
 
 const setIPFSProvider = async (info) => {
@@ -65,7 +67,7 @@ const setIPFSProvider = async (info) => {
 }
 
 const getEthAddress = async () => {
-  return await AsyncStorage.getItem(`${await getPerUserStoreKey()}.${ETH_ADDRESS}`); 
+  return await AsyncStorage.getItem(`${await getPerUserStoreKey()}.${ETH_ADDRESS}`);
 }
 
 const setEthAddress = async (address) => {
@@ -75,7 +77,7 @@ const setEthAddress = async (address) => {
 const records = () => {
   let p = new Promise(async function(resolve, reject) {
     try {
-      let response = await AsyncStorage.getItem(`${await getPerUserStoreKey()}.${RECORDS}`); 
+      let response = await AsyncStorage.getItem(`${await getPerUserStoreKey()}.${RECORDS}`);
       let result = await JSON.parse(response) || [];
       resolve(result);
     } catch (e) {


### PR DESCRIPTION
This PR enables support for using corald as an authenticated and rate-limited IPFS proxy server:
* A new settings control lets use select whether they use the corald server, or a custom IPFS server
* ipfs client code has been reworked to use different endpoints in corald case
* ipfs client code includes the `X-MyCoral-AccessToken` header

The corresponding changes to `corald` and `server-ops` have been pushed and deployed, so the infrastructure is in place to start using this branch immediately.

KNOWN ISSUES:

Previously we were authenticating once and then storing the username forever without validating the token. Now each time a user interacts with IPFS, we are validating their auth token. If it expires or is invalid for any reason, we are showing a generic error. Instead we should kick them back to a login screen.