### PR TITLE
Switched to Expo's react-native fork (fixes #37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "next-frame": "^0.2.3",
     "node-forge": "^0.7.1",
     "react": "16.0.0",
-    "react-native": "0.50.3",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-23.0.0.tar.gz",
     "react-native-elements": "^0.19.0",
     "react-native-image-zoom-viewer": "^2.0.20",
     "react-native-keyboard-aware-scroll-view": "^0.4.3",


### PR DESCRIPTION
When pulling this change, you may need to remove your `node_modules` directory and reinstall with `npm install`.

References:

[Why does Expo use a fork of React Native?](https://docs.expo.io/versions/latest/introduction/faq.html#why-does-expo-use-a-fork-of-react-native)

https://stackoverflow.com/questions/45187220/not-using-the-expo-fork-of-react-native