### PR TITLE
Fix status bar issues.

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Coral Health",
     "slug": "mycoral-patient",
-    "version": "0.2.0",
+    "version": "0.2.2",
     "sdkVersion": "23.0.0",
     "privacy": "unlisted",
     "scheme": "coralhealth",
@@ -13,7 +13,7 @@
     "icon": "./assets/icon.png",
     "ios": {
       "bundleIdentifier": "com.mycoralhealth.Patient",
-      "buildNumber": "0.2.0"
+      "buildNumber": "0.2.2"
     },
     "android": {
       "package": "com.mycoralhealth.Patient",

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,6 +3,7 @@ import { View, Image, Platform, Modal, TouchableOpacity, ActivityIndicator, Stat
 import { Text, Button, Icon, List, ListItem } from 'react-native-elements';
 import { PHOTO_RECORD_TEST } from './utilities/recordTypes';
 import { NavigationActions, SafeAreaView } from 'react-navigation';
+import { Constants } from 'expo';
 
 
 import store from './utilities/store';
@@ -38,8 +39,8 @@ export class CoralHeader extends React.Component {
   render() {
     return (
       <SafeAreaView forceInset={{top:'always'}}>
-        <StatusBar barStyle="dark-content"/>
-        <View style={{ flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: colors.green, borderTopWidth: 1, borderTopColor: colors.green, marginTop: 0}}>
+        <StatusBar barStyle={(Platform.OS === 'ios') ? "dark-content" : "light-content"}/>
+        <View style={{ flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: colors.green, borderTopWidth: 1, borderTopColor: colors.green, marginTop: (Platform.OS === 'ios') ? 0 : -Constants.statusBarHeight}}>
           <View style={{ backgroundColor: 'white', width: 80, height: 80, justifyContent: 'center'}}>
             <Image style={{ width: 80, height: 80 }} source={require('../assets/corner-logo.png')} />
           </View>

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Image, Platform, Modal, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { View, Image, Platform, Modal, TouchableOpacity, ActivityIndicator, StatusBar } from 'react-native';
 import { Text, Button, Icon, List, ListItem } from 'react-native-elements';
 import { PHOTO_RECORD_TEST } from './utilities/recordTypes';
 import { NavigationActions, SafeAreaView } from 'react-navigation';
@@ -38,7 +38,8 @@ export class CoralHeader extends React.Component {
   render() {
     return (
       <SafeAreaView forceInset={{top:'always'}}>
-        <View style={{ flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: colors.green, borderTopWidth: 1, borderTopColor: colors.green, marginTop: (Platform.OS === 'ios') ? 20 : 0}}>
+        <StatusBar barStyle="dark-content"/>
+        <View style={{ flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: colors.green, borderTopWidth: 1, borderTopColor: colors.green, marginTop: 0}}>
           <View style={{ backgroundColor: 'white', width: 80, height: 80, justifyContent: 'center'}}>
             <Image style={{ width: 80, height: 80 }} source={require('../assets/corner-logo.png')} />
           </View>

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"version" : "Version 0.2.1"}
+{"version" : "Version 0.2.2"}


### PR DESCRIPTION
Fixes #65 

The fix removes the artificial 20 pixels spacing that was put before using SafeAreaView and also adds explicit styling on the status bar to use what the Expo puts when the app is ran within the Expo app.