### PR TITLE
Reseting the navigation stack after logging in.

### DIFF
--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { View, StyleSheet, Image } from 'react-native';
 import { Button, Text } from 'react-native-elements';
 import { AuthSession } from 'expo';
+import { NavigationActions } from 'react-navigation';
 
 import store from '../utilities/store';
 import { colors, MessageIndicator } from '../ui';
@@ -41,8 +42,11 @@ export class LoginScreen extends Component {
 
     if (this.state.loggedIn) {
       // Logged in: navigate to the app
-      this.props.navigation.navigate('MainTabs');
-      return;
+      const resetAction = NavigationActions.reset({
+        index: 0,
+        actions: [NavigationActions.navigate({ routeName: "MainTabs" })],
+      });
+      return this.props.navigation.dispatch(resetAction);
     }
 
     if (this.state.loading || this.state.error) {


### PR DESCRIPTION
The login screen is left on the navigation stack after we enter the app. If someone double taps a back button or adds two backs onto the navigation stack in some way then the stack will revert all the way to the login screen.

We can just reset the stack once we login and set the main navigation bar to be the base state.

related to https://github.com/mycoralhealth/mycoral-patient/issues/72

@nosequeldeebee 
@grcevski 